### PR TITLE
Run VCR tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 	golangci-lint run ./...
 
 test:
-	TF_ACC=1 go test ./lavinmq -v -count 1
+	TF_ACC=1 go test ./lavinmq -v -count 1 -parallel 10
 
 clean:
 	rm -f terraform-provider-lavinmq

--- a/lavinmq/data_source_exchanges_test.go
+++ b/lavinmq/data_source_exchanges_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccDataSourceExchanges_Basic(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -53,6 +54,7 @@ func TestAccDataSourceExchanges_Basic(t *testing.T) {
 }
 
 func TestAccDataSourceExchanges_DefaultExchanges(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -76,6 +78,7 @@ func TestAccDataSourceExchanges_DefaultExchanges(t *testing.T) {
 }
 
 func TestAccDataSourceExchanges_NonExistingVhost(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/data_source_permissions_test.go
+++ b/lavinmq/data_source_permissions_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccDataSourcePermissions_Basic(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -66,6 +67,7 @@ func TestAccDataSourcePermissions_Basic(t *testing.T) {
 }
 
 func TestAccDataSourcePermissions_Empty(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -82,6 +84,7 @@ func TestAccDataSourcePermissions_Empty(t *testing.T) {
 }
 
 func TestAccDataSourcePermissions_FilterByVhost(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -126,6 +129,7 @@ func TestAccDataSourcePermissions_FilterByVhost(t *testing.T) {
 }
 
 func TestAccDataSourcePermissions_FilterByUser(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -166,6 +170,7 @@ func TestAccDataSourcePermissions_FilterByUser(t *testing.T) {
 }
 
 func TestAccDataSourcePermissions_FilterByVhostAndUser(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/data_source_policies_test.go
+++ b/lavinmq/data_source_policies_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccDataSourcePolicies_Basic(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -60,6 +61,7 @@ func TestAccDataSourcePolicies_Basic(t *testing.T) {
 }
 
 func TestAccDataSourcePolicies_Empty(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -82,6 +84,7 @@ func TestAccDataSourcePolicies_Empty(t *testing.T) {
 }
 
 func TestAccDataSourcePolicies_NonExistingVhost(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/data_source_queues_test.go
+++ b/lavinmq/data_source_queues_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccDataSourceQueues_Basic(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -26,6 +27,7 @@ func TestAccDataSourceQueues_Basic(t *testing.T) {
 }
 
 func TestAccDataSourceQueues_Empty(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -49,6 +51,7 @@ func TestAccDataSourceQueues_Empty(t *testing.T) {
 }
 
 func TestAccDataSourceQueues_NonExistingVhost(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/data_source_users_test.go
+++ b/lavinmq/data_source_users_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccDataSourceUsers_Basic(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -47,6 +48,7 @@ func TestAccDataSourceUsers_Basic(t *testing.T) {
 }
 
 func TestAccDataSourceUsers_DefaultUser(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/data_source_vhosts_test.go
+++ b/lavinmq/data_source_vhosts_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccDataSourceVhosts_Basic(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -38,6 +39,7 @@ func TestAccDataSourceVhosts_Basic(t *testing.T) {
 }
 
 func TestAccDataSourceVhosts_DefaultVhost(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/resource_exchange_test.go
+++ b/lavinmq/resource_exchange_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccExchange_Basic(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames            = []string{"exchanges/exchange_basic"}
 		exchangeResourceName = "lavinmq_exchange.vcr_test"
@@ -48,6 +49,7 @@ func TestAccExchange_Basic(t *testing.T) {
 }
 
 func TestAccExchange_VhostScenarios(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNamesCustomVhost = []string{"exchanges/exchange_custom_vhost"}
 		exchangeResourceName = "lavinmq_exchange.vcr_test"
@@ -88,6 +90,7 @@ func testAccExchangeImportStateIdFunc(s *terraform.State) (string, error) {
 }
 
 func TestAccExchange_AllTypes(t *testing.T) {
+	t.Parallel()
 	exchangeTypes := []struct {
 		name     string
 		filename string
@@ -132,6 +135,7 @@ func TestAccExchange_AllTypes(t *testing.T) {
 }
 
 func TestAccExchange_BooleanAttributes(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNamesDurable     = []string{"exchanges/exchange_durable"}
 		fileNamesAutoDelete  = []string{"exchanges/exchange_auto_delete"}
@@ -179,6 +183,7 @@ func TestAccExchange_BooleanAttributes(t *testing.T) {
 }
 
 func TestAccExchange_Drift(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames = []string{"exchanges/exchange_drift"}
 
@@ -202,6 +207,7 @@ func TestAccExchange_Drift(t *testing.T) {
 }
 
 func TestAccExchange_WithArguments(t *testing.T) {
+	t.Parallel()
 	exchangeResourceName := "lavinmq_exchange.test_exchange"
 
 	lavinMQResourceTest(t, resource.TestCase{

--- a/lavinmq/resource_permission_test.go
+++ b/lavinmq/resource_permission_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccPermission_Basic(t *testing.T) {
+	t.Parallel()
 	var (
 		permissionResourceName = "lavinmq_permission.test_permission"
 	)
@@ -44,6 +45,7 @@ func TestAccPermission_Basic(t *testing.T) {
 }
 
 func TestAccPermission_Update(t *testing.T) {
+	t.Parallel()
 	var (
 		permissionResourceName = "lavinmq_permission.test_permission"
 	)
@@ -105,6 +107,7 @@ func TestAccPermission_Update(t *testing.T) {
 }
 
 func TestAccPermission_Import(t *testing.T) {
+	t.Parallel()
 	var (
 		permissionResourceName = "lavinmq_permission.test_permission"
 	)
@@ -149,6 +152,7 @@ func TestAccPermission_Import(t *testing.T) {
 }
 
 func TestAccPermission_Drift(t *testing.T) {
+	t.Parallel()
 	lavinMQResourceTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/lavinmq/resource_policy_test.go
+++ b/lavinmq/resource_policy_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccPolicy_Import(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames          = []string{"policies/policy"}
 		policyResourceName = "lavinmq_policy.test_policy"
@@ -47,6 +48,7 @@ func TestAccPolicy_Import(t *testing.T) {
 }
 
 func TestAccPolicy_Update(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames          = []string{"policies/policy"}
 		policyResourceName = "lavinmq_policy.test_policy"
@@ -104,6 +106,7 @@ func TestAccPolicy_Update(t *testing.T) {
 }
 
 func TestAccPolicy_AddDefinitions(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames          = []string{"policies/policy"}
 		policyResourceName = "lavinmq_policy.dead_letter_policy"
@@ -154,6 +157,7 @@ func TestAccPolicy_AddDefinitions(t *testing.T) {
 }
 
 func TestAccPolicy_InvalidApplyTo(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames = []string{"policies/policy"}
 

--- a/lavinmq/resource_queue_test.go
+++ b/lavinmq/resource_queue_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccQueue_Import(t *testing.T) {
+	t.Parallel()
 	queueResourceName := "lavinmq_queue.test_queue"
 
 	lavinMQResourceTest(t, resource.TestCase{
@@ -42,6 +43,7 @@ func TestAccQueue_Import(t *testing.T) {
 }
 
 func TestAccQueue_WithArguments(t *testing.T) {
+	t.Parallel()
 	queueResourceName := "lavinmq_queue.test_queue"
 
 	lavinMQResourceTest(t, resource.TestCase{
@@ -74,6 +76,7 @@ func TestAccQueue_WithArguments(t *testing.T) {
 }
 
 func TestAccQueue_PauseUnpause(t *testing.T) {
+	t.Parallel()
 	queueResourceName := "lavinmq_queue.test_queue"
 
 	lavinMQResourceTest(t, resource.TestCase{

--- a/lavinmq/resource_user_test.go
+++ b/lavinmq/resource_user_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccUser_Password(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames        = []string{"users/user_with_password"}
 		userResourceName = "lavinmq_user.user"
@@ -49,6 +50,7 @@ func TestAccUser_Password(t *testing.T) {
 }
 
 func TestAccUser_PasswordHash(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames        = []string{"users/user_with_password_hash"}
 		userResourceName = "lavinmq_user.user"

--- a/lavinmq/resource_vhost_test.go
+++ b/lavinmq/resource_vhost_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccVhost_Basic(t *testing.T) {
+	t.Parallel()
 	var (
 		fileNames         = []string{"vhosts/vhost_without_limits"}
 		vhostResourceName = "lavinmq_vhost.vcr_test"


### PR DESCRIPTION
Since we're using VCR for recorded HTTP interactions, vhost conflicts are not a concern during playback mode

Fixes #31