### PR TITLE
Fix parallel test race condition in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,16 @@ jobs:
         with:
           go-version-file: .go-version
 
+      - uses: hashicorp/setup-terraform@v3
+        id: setup-terraform
+        with:
+          terraform_wrapper: false
+
       - name: Run tests
         run: go test ./lavinmq/ -v
         env:
           TF_ACC: 1
+          TF_ACC_TERRAFORM_PATH: ${{ steps.setup-terraform.outputs.terraform_path }}
 
       - name: Build for single target with GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0


### PR DESCRIPTION
Pre-install Terraform binary to avoid 'text file busy' error when multiple parallel tests try to access shared temp binary installation.

Set TF_ACC_TERRAFORM_PATH to use pre-installed binary instead of letting terraform-plugin-testing framework download it per test.