### PR TITLE
Quiet down dependabot: 7d cooldown, group, majors-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,32 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: "github-actions"
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,6 @@ updates:
       github-actions:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor
+    # No semver-patch/minor ignore here: actions are SHA-pinned, so Dependabot
+    # security alerts don't fire for them. Letting all version updates through
+    # is how patch-level security fixes reach us.


### PR DESCRIPTION
Reduces PR noise from dependabot while preserving security updates.

- Cooldown: wait 7 days after a release before opening a PR. Reduces risk of supply chain attacks.
- Ignore semver-patch and semver-minor bumps for `gomod` only (security updates still flow through since those deps are semver-pinned, so Dependabot opens a `security-update:` PR that bypasses the version-update ignore).
- For `github-actions` all version updates flow — they're SHA-pinned (#113), which means Dependabot doesn't fire security alerts on them, so the regular patch/minor version-update PRs are our only signal for security fixes there.
- Group remaining bumps per ecosystem into a single PR.