### PR TITLE
Pin GitHub Actions to full-length SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: .go-version
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         id: setup-terraform
         with:
           terraform_wrapper: false

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,14 +15,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: .go-version
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,21 +12,21 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: .go-version
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         id: setup-terraform
         with:
           terraform_wrapper: false
 
-      - uses: cloudamqp/lavinmq-action@main
+      - uses: cloudamqp/lavinmq-action@df2d45f4374c5afe2d536fd78c26c4e394315035 # v1.1.0
 
       - name: Run tests against LavinMQ
         run: go test ./lavinmq/ -v


### PR DESCRIPTION
Want to harden our setup against compromised dependencies. Tags can be altered and replaced, while git hashes are derived from the content and ensure it doesn't change.

Dependabot understands SHA pins and will continue to suggest bumps, but the security checks have a gap: Dependabot can't map a SHA back to a version range, so GHSA advisories don't match SHA-pinned actions and no security alert fires. By leaving patch/minor bumps enabled for GitHub Actions in #112 (Go modules stay majors-only since their security alerts still fire normally) we'll get the important security fixes (42c6966517e2471a36b037037cfaccd542e38e53) and we'll see how noisy it gets.

### Pinned versions
| Action | Pin |
| --- | --- |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) |
| `actions/setup-go` | `4a3601121dd01d1626a1e23e37211e3254c1c06c` (v6.4.0) |
| `hashicorp/setup-terraform` | `dfe3c3f87815947d99a8997f908cb6525fc44e9e` (v4.0.1) |
| `cloudamqp/lavinmq-action` | `df2d45f4374c5afe2d536fd78c26c4e394315035` (v1.1.0 — previously `@main`) |